### PR TITLE
Debianize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+test.py
 # Compiled python modules.
 *.pyc
 

--- a/pyosf/constants.py
+++ b/pyosf/constants.py
@@ -11,10 +11,13 @@ PROJECT_NAME = 'pyosf'
 APPLICATION_SCOPES = 'osf.full_write'
 
 from os import path
+import sys
+
 home = path.expanduser("~")
-PYOSF_FOLDER = path.join(home, '.pyosf')
+if sys.platform.startswith("linux"):
+    PYOSF_FOLDER = path.join(home, '.local', 'share', 'pyosf')
+else:
+    PYOSF_FOLDER = path.join(home, '.pyosf')
 
 SHA = "md5"  # could switch to "sha256"
-
-import sys
 PY3 = sys.version_info > (3,)

--- a/pyosf/constants.py
+++ b/pyosf/constants.py
@@ -14,10 +14,10 @@ from os import path
 import sys
 
 home = path.expanduser("~")
-if sys.platform.startswith("linux"):
+PYOSF_FOLDER = path.join(home, '.pyosf')
+
+if sys.platform.startswith("linux") and not path.isfile(PYOSF_FOLDER):
     PYOSF_FOLDER = path.join(home, '.local', 'share', 'pyosf')
-else:
-    PYOSF_FOLDER = path.join(home, '.pyosf')
 
 SHA = "md5"  # could switch to "sha256"
 PY3 = sys.version_info > (3,)


### PR DESCRIPTION
(I accidentally created a new pull request)

The updated code now checks under Linux, if an old pyosf folder exists and uses the old one in this case.

".local/shared" means that these are local user files shared by all applications. Other users have no access, but all applications of this user using .pyosf can use the same token.