### PR TITLE
Add ‘requests’ dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
     keywords='Open Science Framework PsychoPy',
     packages=find_packages(exclude=['docs', 'tests']),
     # $ pip install -e .[dev,test]
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'coverage'],
+    setup_requires=['pytest-runner', 'requests'],
+    tests_require=['pytest', 'coverage', 'requests'],
     package_data={
         'sample': ['package_data.dat'],
     },


### PR DESCRIPTION
Hi Jon,

I'm doing some legwork for adding psychopy to conda-forge (automatic compilation on all OS's, easy conda install without adding "erik" channel"). All dependencies need to be in conda-forge, though, so I'm adding pyosf there with pr conda-forge/staged-recipes#2249

Doing that, I noticed that requests wasn't included as a dep in pyosf itself, so I'm adding that in here. It shouldn't make a difference through conda-forge, but may for pip.