### PR TITLE
Include license and readme in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md


### PR DESCRIPTION
It is very important to include the license for legal reasons.  Including the readme as well as helpful.